### PR TITLE
Fix #10: Material Theme FloatLabel issue

### DIFF
--- a/themes/material/extensions/_float_label.scss
+++ b/themes/material/extensions/_float_label.scss
@@ -32,7 +32,7 @@
         textarea.p-filled ~ label,
         .p-inputwrapper-focus ~ label,
         .p-inputwrapper-filled ~ label {
-            top: .25rem !important;
+            top: -1.25rem !important;
             margin-top: 0;
             background: transparent;
         }


### PR DESCRIPTION
Solved the issue of overwriting the label by changing the value of the "top" variable in the material themes. 