### PR TITLE
Fixed #18 - SplitButton: menu icon not visible in large size

### DIFF
--- a/theme-base/components/button/_splitbutton.scss
+++ b/theme-base/components/button/_splitbutton.scss
@@ -109,6 +109,10 @@
             @include scaledFontSize($fontSize, $scaleLG);
             @include scaledPadding($buttonPadding, $scaleLG);
 
+            &.p-button-icon-only {
+                width: auto;
+            }
+            
             .p-button-icon {
                 @include scaledFontSize($primeIconFontSize, $scaleLG);
             }


### PR DESCRIPTION
https://github.com/primefaces/primereact/issues/4483