### PR TITLE
Added .p-fileupload-highlight class

### DIFF
--- a/theme-base/components/file/_fileupload.scss
+++ b/theme-base/components/file/_fileupload.scss
@@ -24,7 +24,6 @@
 
         &.p-fileupload-highlight {
             border-color: $primaryColor;
-            border-width: 2px;
             border-style: dashed;
             background-color: $highlightBg;
         }

--- a/theme-base/components/file/_fileupload.scss
+++ b/theme-base/components/file/_fileupload.scss
@@ -21,6 +21,13 @@
         color: $panelContentTextColor;
         border-bottom-right-radius: $borderRadius;
         border-bottom-left-radius: $borderRadius;
+
+        &.p-fileupload-highlight {
+            border-color: $primaryColor;
+            border-width: 2px;
+            border-style: dashed;
+            background-color: $highlightBg;
+        }
     }
 
     .p-progressbar {


### PR DESCRIPTION
Added file .p-fileupload-highlight class to fix https://github.com/primefaces/primereact/pull/4646

I have follow the same idea like:
PrimeNG: https://github.com/primefaces/primeng-sass-theme/pull/24
PrimeVue: https://github.com/primefaces/primevue-sass-theme/pull/14

## PROBLEM

when I'm trying to drag over my file in the component (nothing was happening)

![problem fileupload primereact](https://github.com/primefaces/primereact/assets/19764334/584b8318-c908-4a85-8e89-f0433e8bfb6e)

## SOLUTION
![fixed fileupload primereact](https://github.com/primefaces/primereact/assets/19764334/e9398ddd-fe94-4a87-8f59-f82b823cdaa1)