### PR TITLE
Adjust info message color

### DIFF
--- a/themes/lara/lara-light/_variables.scss
+++ b/themes/lara/lara-light/_variables.scss
@@ -585,10 +585,10 @@ $toastTitleFontWeight:700 !default;
 $toastDetailMargin:$inlineSpacing 0 0 0 !default;
 
 //severities
-$infoMessageBg:#e9e9ff !default;
-$infoMessageBorder:solid #696cff !default;
-$infoMessageTextColor:#696cff !default;
-$infoMessageIconColor:#696cff !default;
+$infoMessageBg:#e4f2ff !default;
+$infoMessageBorder:solid #3991ff !default;
+$infoMessageTextColor:#3991ff !default;
+$infoMessageIconColor:#3991ff !default;
 $successMessageBg:#e4f8f0 !default;
 $successMessageBorder:solid #1ea97c !default;
 $successMessageTextColor:#1ea97c !default;


### PR DESCRIPTION
resolves #31

## How I tested it

```
npx sass --update themes/lara/lara-light/teal/theme.scss ../primereact/public/themes/lara-light-teal/theme.css
```

Before: lara-light-teal (and other lara-light themes) is using indigo as its color for "info" message
<img width="1125" alt="image" src="https://github.com/primefaces/primereact-sass-theme/assets/1001890/1d9b34d1-51b3-49fd-b9eb-c97f8e27957d">


After:
<img width="1139" alt="image" src="https://github.com/primefaces/primereact-sass-theme/assets/1001890/b8479a1a-87fd-4798-a6d5-0b8159f69af1">


