### PR TITLE
Updated panel css border radius

### DIFF
--- a/theme-base/components/panel/_panel.scss
+++ b/theme-base/components/panel/_panel.scss
@@ -27,9 +27,12 @@
         border: $panelContentBorder;
         background: $panelContentBg;
         color: $panelContentTextColor;
-        border-bottom-right-radius: $borderRadius;
-        border-bottom-left-radius: $borderRadius;
         border-top: 0 none;
+        
+        &:last-child {
+            border-bottom-right-radius: $borderRadius;
+            border-bottom-left-radius: $borderRadius;
+        }
     }
 
     .p-panel-footer {
@@ -37,6 +40,8 @@
         border: $panelFooterBorder;
         background: $panelFooterBg;
         color: $panelFooterTextColor;
+        border-bottom-right-radius: $borderRadius;
+        border-bottom-left-radius: $borderRadius;
         border-top: 0 none;
     }
 }


### PR DESCRIPTION
Expected behaviour
![image](https://github.com/primefaces/primereact-sass-theme/assets/29578451/bbfb5e3f-e4e6-4a31-9f8f-dae5a1bce33a)
Current behaviour
![image](https://github.com/primefaces/primereact-sass-theme/assets/29578451/5d4d5d89-5b8a-4d3f-a2e9-b5fe2e233575)

Summary: When the footer enabled border radius is not working properly 