### PR TITLE
fix(toast): Remove unnecessary border-width

### DIFF
--- a/theme-base/components/messages/_toast.scss
+++ b/theme-base/components/messages/_toast.scss
@@ -7,8 +7,7 @@
         border-radius: $borderRadius;
 
         .p-toast-message-content {
-            padding: $toastPadding;
-            border-width: $toastBorderWidth;
+            padding: 1rem;
 
             .p-toast-message-text {
                 margin: $toastMessageTextMargin;

--- a/theme-base/components/messages/_toast.scss
+++ b/theme-base/components/messages/_toast.scss
@@ -7,7 +7,7 @@
         border-radius: $borderRadius;
 
         .p-toast-message-content {
-            padding: 1rem;
+            padding: $toastPadding;
 
             .p-toast-message-text {
                 margin: $toastMessageTextMargin;


### PR DESCRIPTION
Fix #45

Removing the line, solves the problem.

--- 

## PROBLEM

![image](https://github.com/primefaces/primereact-sass-theme/assets/19764334/d6ada5af-af45-4f7d-bcbc-460871c446dc)

## AFTER SOLUTION

![image](https://github.com/primefaces/primereact-sass-theme/assets/19764334/48de15da-7932-4ced-8f82-22714c66609c)

### NOTE: is not necessary because the border left of the component is implemented in the div parent:

![image](https://github.com/primefaces/primereact-sass-theme/assets/19764334/c48bedf6-6727-4e21-bf49-7ae20dc2f687)
