### PR TITLE
Fix: Remove directly import of font-family in root

### DIFF
--- a/themes/arya/_variables.scss
+++ b/themes/arya/_variables.scss
@@ -908,12 +908,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade800};
 	--surface-b: #{$shade900};
 	--surface-c: #{$hoverBg};

--- a/themes/bootstrap4/bootstrap4-dark/_variables_dark.scss
+++ b/themes/bootstrap4/bootstrap4-dark/_variables_dark.scss
@@ -852,12 +852,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade800};
 	--surface-b: #{$shade900};
 	--surface-c: #{$hoverBg};

--- a/themes/bootstrap4/bootstrap4-light/_variables_light.scss
+++ b/themes/bootstrap4/bootstrap4-light/_variables_light.scss
@@ -853,12 +853,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade000};
 	--surface-b: #{$shade100};
 	--surface-c: #{$shade200};

--- a/themes/fluent/fluent-light/_variables.scss
+++ b/themes/fluent/fluent-light/_variables.scss
@@ -910,12 +910,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$white};
 	--surface-b: #{$neutralLighterAlt};
 	--surface-c: #{$neutralLighter};

--- a/themes/lara/lara-dark/_variables.scss
+++ b/themes/lara/lara-dark/_variables.scss
@@ -857,10 +857,9 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: "Inter var", sans-serif;
 	font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 	font-variation-settings: normal;
-	--font-family: "Inter var", sans-serif;
+	--font-family: #{$fontFamily};
 	--font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 	--surface-a: #{$shade800};
 	--surface-b: #{$shade900};

--- a/themes/lara/lara-light/_variables.scss
+++ b/themes/lara/lara-light/_variables.scss
@@ -857,10 +857,9 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: "Inter var", sans-serif;
 	font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 	font-variation-settings: normal;
-	--font-family: "Inter var", sans-serif;
+	--font-family: #{$fontFamily};
 	--font-feature-settings: "cv02", "cv03", "cv04", "cv11";
 	--surface-a: #{$shade000};
 	--surface-b: #{$shade100};

--- a/themes/luna/_variables.scss
+++ b/themes/luna/_variables.scss
@@ -830,12 +830,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #191919;
 	--surface-b: #191919;
 	--surface-c: #4c4c4c;

--- a/themes/material/material-dark/_variables.scss
+++ b/themes/material/material-dark/_variables.scss
@@ -856,10 +856,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: Roboto, "Helvetica Neue Light", "Helvetica Neue", Helvetica,
-		Arial, "Lucida Grande", sans-serif;
-	--font-family: Roboto, "Helvetica Neue Light", "Helvetica Neue", Helvetica,
-		Arial, "Lucida Grande", sans-serif;
+	--font-family: #{$fontFamily};
 	--surface-a: #1e1e1e;
 	--surface-b: #121212;
 	--surface-c: hsla(0, 0%, 100%, 0.04);

--- a/themes/material/material-light/_variables.scss
+++ b/themes/material/material-light/_variables.scss
@@ -856,10 +856,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: Roboto, "Helvetica Neue Light", "Helvetica Neue", Helvetica,
-		Arial, "Lucida Grande", sans-serif;
-	--font-family: Roboto, "Helvetica Neue Light", "Helvetica Neue", Helvetica,
-		Arial, "Lucida Grande", sans-serif;
+	--font-family: #{$fontFamily};
 	--surface-a: #ffffff;
 	--surface-b: #fafafa;
 	--surface-c: rgba(0, 0, 0, 0.04);

--- a/themes/mira/_variables.scss
+++ b/themes/mira/_variables.scss
@@ -887,8 +887,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: "Inter", sans-serif;
-	--font-family: "Inter", sans-serif;
+	--font-family: #{$fontFamily};
 	--surface-a: #{$white};
 	--surface-b: #{$white100};
 	--surface-c: #{$white300};

--- a/themes/nano/_variables.scss
+++ b/themes/nano/_variables.scss
@@ -914,12 +914,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade000};
 	--surface-b: #{$shade100};
 	--surface-c: #{$shade200};

--- a/themes/nova/_variables.scss
+++ b/themes/nova/_variables.scss
@@ -829,12 +829,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #ffffff;
 	--surface-b: #f4f4f4;
 	--surface-c: #eaeaea;

--- a/themes/rhea/_variables.scss
+++ b/themes/rhea/_variables.scss
@@ -846,12 +846,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #ffffff;
 	--surface-b: #f4f4f4;
 	--surface-c: #eaeaea;

--- a/themes/saga/_variables.scss
+++ b/themes/saga/_variables.scss
@@ -909,12 +909,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade000};
 	--surface-b: #{$shade100};
 	--surface-c: #{$shade200};

--- a/themes/soho/soho-dark/_variables.scss
+++ b/themes/soho/soho-dark/_variables.scss
@@ -909,8 +909,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: Lato, Helvetica, sans-serif;
-	--font-family: Lato, Helvetica, sans-serif;
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade800};
 	--surface-b: #{$shade900};
 	--surface-c: #{$hoverBg};

--- a/themes/soho/soho-light/_variables.scss
+++ b/themes/soho/soho-light/_variables.scss
@@ -912,8 +912,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: Lato, Helvetica, sans-serif;
-	--font-family: Lato, Helvetica, sans-serif;
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade000};
 	--surface-b: #{$shade100};
 	--surface-c: #{$shade200};

--- a/themes/tailwind/tailwind-light/_variables.scss
+++ b/themes/tailwind/tailwind-light/_variables.scss
@@ -852,8 +852,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+	--font-family: #{$fontFamily};
   --surface-a: #{$shade000};
   --surface-b: #{$shade100};
   --surface-c: #{$shade200};

--- a/themes/vela/_variables.scss
+++ b/themes/vela/_variables.scss
@@ -907,12 +907,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
-	--font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-		Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-		"Segoe UI Symbol";
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade800};
 	--surface-b: #{$shade900};
 	--surface-c: #{$hoverBg};

--- a/themes/viva/viva-dark/_variables.scss
+++ b/themes/viva/viva-dark/_variables.scss
@@ -849,8 +849,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-  font-family: Poppins, sans-serif;
-  --font-family: Poppins, sans-serif;
+	--font-family: #{$fontFamily};
   --surface-a: #{$shade800};
   --surface-b: #{$shade900};
   --surface-c: #{$hoverBg};

--- a/themes/viva/viva-light/_variables.scss
+++ b/themes/viva/viva-light/_variables.scss
@@ -916,8 +916,7 @@ $imagePreviewActionIconFontSize: 1.5rem !default;
 $imagePreviewActionIconBorderRadius: 50% !default;
 
 :root {
-	font-family: Poppins, sans-serif;
-	--font-family: Poppins, sans-serif;
+	--font-family: #{$fontFamily};
 	--surface-a: #{$shade000};
 	--surface-b: #{$shade100};
 	--surface-c: #{$shade200};


### PR DESCRIPTION
This adjustment prevents discrepancies when you need to change the font.

Before, if you changed only the $fontFamily variable, it was not considered, as it was imported directly into :root.