### PR TITLE
Theme lara-light-teal: Replace background color of highlight

### DIFF
--- a/themes/lara/lara-light/teal/theme.scss
+++ b/themes/lara/lara-light/teal/theme.scss
@@ -4,7 +4,7 @@ $primaryDarkColor: #0d9488 !default;
 $primaryDarkerColor: #0f766e !default;
 $primaryTextColor: #ffffff !default;
 
-$highlightBg: #0f766e !default;
+$highlightBg: #f0fffb !default;
 $highlightTextColor: $primaryDarkerColor !default;
 $highlightFocusBg: rgba($primaryColor, 0.24) !default;
 


### PR DESCRIPTION
Fixes #75 
Fixes #69 

Original color: #0f766e (same as text color, causing issues)
Replacement color: #f0fffb

Replacement color was chosen compared to the lara-light-blue theme (not sure if this method is okay): In HSL, H is 10 less than text color, S & L are the same as lara-light-blue's S & L.