### PR TITLE
fix(#7080): apply bottom border width in dataTable footer

### DIFF
--- a/theme-base/components/data/_datatable.scss
+++ b/theme-base/components/data/_datatable.scss
@@ -266,10 +266,10 @@
         .p-datatable-tfoot {
             > tr {
                 > td {
-                    border-width: 1px 0 1px 1px;
+                    border-width: 0 0 1px 1px;
 
                     &:last-child {
-                        border-width: 1px 1px 1px 1px;
+                        border-width: 0 1px 1px 1px;
                     }
                 }
             }
@@ -294,20 +294,6 @@
 
                     &:last-child {
                         border-width: 0 1px 1px 1px;
-                    }
-                }
-            }
-        }
-
-        &:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody {
-            > tr {
-                &:last-child {
-                    > td {
-                        border-width: 0 0 0 1px;
-
-                        &:last-child {
-                            border-width: 0 1px 0 1px;
-                        }
                     }
                 }
             }

--- a/themes/material/material-dark/_variables.scss
+++ b/themes/material/material-dark/_variables.scss
@@ -520,7 +520,7 @@ $tableFooterCellPadding: 1rem 1rem !default;
 $tableFooterCellBg: #1e1e1e !default;
 $tableFooterCellTextColor: $textColor !default;
 $tableFooterCellFontWeight: 500 !default;
-$tableFooterCellBorder: 1px solid 3404040 !default;
+$tableFooterCellBorder: 1px solid #404040 !default;
 $tableFooterCellBorderWidth: 0 0 1px 0 !default;
 $tableResizerHelperBg: $primaryColor !default;
 $tableDragHelperBg: rgba($primaryColor, 0.16) !default;


### PR DESCRIPTION
### Defect Fixes
- issue: https://github.com/primefaces/primereact/issues/7080
- When the `footerColumnGroup` in a dataTable is shorter than the total number of columns, 
- the border width is not applied to some columns.

### How to Resolve
- Previously, the td styles at the top of the footer were adjusted based on whether the footer was present. 
- However, when the length of the footer's columns was shorter than the total number of columns, some td elements did not receive the correct border styles. 
- To resolve this, I removed the code that modified the td styles based on the presence of the footer:

```scss
// .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
//     border-width: 0 0 0 1px;
// }
// .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
//     border-width: 0 1px 0 1px;
// }
```

<br/>

Now, instead of changing styles based on the footer's presence, I apply a consistent border-width to all td elements. When the footer is present, I specifically set the border styles for the td elements in the footer:

```scss
.landing-themes .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
  // border-width: 1px 0 1px 1px; before
  border-width: 0 0 1px 1px;  // updated
}
.landing-themes .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
  // border-width: 1px 1px 1px 1px; 
  border-width: 0 1px 1px 1px;  // updated
}
