### PR TITLE
style: update icon style for autocomplete

### DIFF
--- a/theme-base/components/input/_inputicon.scss
+++ b/theme-base/components/input/_inputicon.scss
@@ -4,12 +4,14 @@
     width: 100%;
 }
 
-.p-icon-field-left > .p-input-icon:first-of-type {
+.p-icon-field-left > .p-input-icon {
     left: nth($inputPadding, 2);
     color: $inputIconColor;
+    z-index: 1;
 }
 
-.p-icon-field-right > .p-input-icon:last-of-type  {
+.p-icon-field-right > .p-input-icon  {
     right: nth($inputPadding, 2);
     color: $inputIconColor;
+    z-index: 1;
 }

--- a/theme-base/components/input/_inputtext.scss
+++ b/theme-base/components/input/_inputtext.scss
@@ -72,6 +72,10 @@
     padding-right: nth($inputPadding, 2) * 2 + $primeIconFontSize;
 }
 
+.p-icon-field-right > .p-autocomplete .p-inputtext {
+    padding-right: nth($inputPadding, 2) * 2 + $primeIconFontSize;
+}
+
 @include placeholder {
     color: $inputPlaceholderTextColor;
 }

--- a/theme-base/components/input/_inputtext.scss
+++ b/theme-base/components/input/_inputtext.scss
@@ -60,6 +60,10 @@
     padding-left: nth($inputPadding, 2) * 2 + $primeIconFontSize;
 }
 
+.p-icon-field-left > .p-autocomplete .p-inputtext {
+    padding-left: nth($inputPadding, 2) * 2 + $primeIconFontSize;
+}
+
 .p-icon-field-left.p-float-label > label {
     left: nth($inputPadding, 2) * 2 + $primeIconFontSize;
 }


### PR DESCRIPTION
### Description
- for fix this [issue](https://github.com/primefaces/primereact/issues/7219), I updated `p-icon-field` style
- related PR: 

|before|after|
|---|---|
|<img width="936" alt="스크린샷 2024-11-23 오후 10 30 50" src="https://github.com/user-attachments/assets/3ae830ef-e4fe-4bd0-bb99-f22ca9c3cd99">|<img width="936" alt="스크린샷 2024-11-23 오후 10 29 54" src="https://github.com/user-attachments/assets/62834792-bcb0-40f8-a1c4-510b03eb239c">|